### PR TITLE
Fix: Accepter les CraftTypes en majuscules (MENUISER, FORGER, TISSER)

### DIFF
--- a/backend/src/controllers/projects.ts
+++ b/backend/src/controllers/projects.ts
@@ -8,6 +8,11 @@ import { container } from "../infrastructure/container";
 import { CraftType } from "@prisma/client";
 
 const craftAliasMap: Record<string, CraftType> = {
+  // Valeurs enum (uppercase)
+  TISSER: CraftType.TISSER,
+  FORGER: CraftType.FORGER,
+  MENUISER: CraftType.MENUISER,
+  // Alias (lowercase)
   tisser: CraftType.TISSER,
   forger: CraftType.FORGER,
   "travailler le bois": CraftType.MENUISER,
@@ -19,7 +24,13 @@ const craftAliasMap: Record<string, CraftType> = {
 
 function normalizeCraftTypes(craftTypes: string[]): CraftType[] {
   return craftTypes.map((raw) => {
-    const normalized = craftAliasMap[raw.trim().toLowerCase()];
+    const trimmed = raw.trim();
+    // Try exact match first (for uppercase enum values)
+    let normalized = craftAliasMap[trimmed];
+    // If no match, try lowercase (for aliases)
+    if (!normalized) {
+      normalized = craftAliasMap[trimmed.toLowerCase()];
+    }
     if (!normalized) {
       throw new BadRequestError(`Type d'artisanat invalide: ${raw}`);
     }


### PR DESCRIPTION
Problème:
- ERR Error creating project: Request failed with status code 400
- Backend rejette: "Type d'artisanat invalide: MENUISER"
- Le bot envoie les enums en majuscules mais craftAliasMap n'acceptait que lowercase

Cause:
- craftAliasMap contenait uniquement des alias en minuscules
- normalizeCraftTypes() faisait toLowerCase() sur tout
- Les valeurs enum directes (MENUISER, FORGER, TISSER) n'étaient pas reconnues

Correction (src/controllers/projects.ts):

1. Ajout des valeurs enum en majuscules dans craftAliasMap (lignes 11-14):
   - TISSER: CraftType.TISSER
   - FORGER: CraftType.FORGER
   - MENUISER: CraftType.MENUISER

2. Modification de normalizeCraftTypes() (lignes 25-39):
   - Essaie d'abord une correspondance exacte (pour uppercase)
   - Si échec, essaie en lowercase (pour les alias)
   - Conserve la compatibilité avec les alias existants

Compatibilité:
✅ Valeurs enum uppercase: TISSER, FORGER, MENUISER ✅ Alias lowercase: tisser, forger, "travailler le bois", etc. ✅ Rétrocompatible avec toutes les utilisations existantes

Impact:
- Création de projets depuis le bot fonctionnelle
- API accepte maintenant les deux formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)